### PR TITLE
UPSTREAM: sched/fair: Avoid pulling all tasks in idle balancing

### DIFF
--- a/kernel/sched/fair.c
+++ b/kernel/sched/fair.c
@@ -6104,6 +6104,13 @@ static int move_tasks(struct lb_env *env)
 
 redo:
 	while (!list_empty(tasks)) {
+		/*
+		 * We don't want to steal all, otherwise we may be treated likewise,
+		 * which could at worst lead to a livelock crash.
+		 */
+		if (env->idle != CPU_NOT_IDLE && env->src_rq->nr_running <= 1)
+			break;
+
 		p = list_first_entry(tasks, struct task_struct, se.group_node);
 
 		env->loop++;


### PR DESCRIPTION
In idle balancing where a CPU going idle pulls tasks from another CPU,
a livelock may happen if the CPU pulls all tasks from another, makes
it idle, and this iterates. So just avoid this.

Reported-by: Rabin Vincent <rabin.vincent@axis.com>
Signed-off-by: Yuyang Du <yuyang.du@intel.com>
Signed-off-by: Peter Zijlstra (Intel) <peterz@infradead.org>
Cc: Ben Segall <bsegall@google.com>
Cc: Linus Torvalds <torvalds@linux-foundation.org>
Cc: Mike Galbraith <efault@gmx.de>
Cc: Mike Galbraith <umgwanakikbuti@gmail.com>
Cc: Morten Rasmussen <morten.rasmussen@arm.com>
Cc: Paul Turner <pjt@google.com>
Cc: Peter Zijlstra <peterz@infradead.org>
Cc: Thomas Gleixner <tglx@linutronix.de>
Link: http://lkml.kernel.org/r/20150705221151.GF5197@intel.com
Signed-off-by: Ingo Molnar <mingo@kernel.org>
(cherry picked from commit 985d3a4c11cd28251bcc7925aa2d7a9038910384)
Signed-off-by: Ricky Liang <jcliang@chromium.org>

BUG=chrome-os-partner:45410
TEST=Boot kernel on Oak. Run tests for days and doesn't see kernel lock-ups.

Change-Id: I4e39dd14189fbf27afcc64de255f7d1b7b822b34
Reviewed-on: https://chromium-review.googlesource.com/309510
Commit-Ready: Ricky Liang <jcliang@chromium.org>
Tested-by: Ricky Liang <jcliang@chromium.org>
Reviewed-by: Daniel Kurtz <djkurtz@chromium.org>